### PR TITLE
Expose threshold and fallback on top level

### DIFF
--- a/sgeop/artifacts.py
+++ b/sgeop/artifacts.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 def get_artifacts(
     roads,
     threshold=None,
+    threshold_fallback=None,
     area_threshold_blocks=1e5,
     isoareal_threshold_blocks=0.5,
     area_threshold_circles=5e4,
@@ -45,6 +46,13 @@ def get_artifacts(
     polygons["is_artifact"] = False
     # unless the fai is below the threshold,
     if threshold is None:
+        if not fas.threshold and threshold_fallback:
+            threshold = threshold_fallback
+        elif not fas.threshold and not threshold_fallback:
+            raise ValueError(
+                "No threshold for artifact detection found. Pass explicit "
+                "`threshold` or `threshold_fallback` to provide the value directly."
+            )
         threshold = fas.threshold
     polygons.loc[polygons.face_artifact_index < threshold, "is_artifact"] = True
 
@@ -1126,6 +1134,3 @@ def is_dangle(edgelines):
     ).sum(axis=1)
 
     return (first_sum == 1) | (last_sum == 1)
-
-
-

--- a/sgeop/simplify.py
+++ b/sgeop/simplify.py
@@ -440,6 +440,7 @@ def simplify_network(
     limit_distance=2,
     simplification_factor=2,
     consolidation_tolerance=10,
+    artifact_threshold_fallback=None,
     area_threshold_blocks=1e5,
     isoareal_threshold_blocks=0.5,
     area_threshold_circles=5e4,
@@ -456,6 +457,7 @@ def simplify_network(
     # Identify artifacts
     artifacts, threshold = get_artifacts(
         roads,
+        threshold_fallback=artifact_threshold_fallback,
         area_threshold_blocks=area_threshold_blocks,
         isoareal_threshold_blocks=isoareal_threshold_blocks,
         area_threshold_circles=area_threshold_circles,

--- a/sgeop/simplify.py
+++ b/sgeop/simplify.py
@@ -440,6 +440,7 @@ def simplify_network(
     limit_distance=2,
     simplification_factor=2,
     consolidation_tolerance=10,
+    artifact_threshold=None,
     artifact_threshold_fallback=None,
     area_threshold_blocks=1e5,
     isoareal_threshold_blocks=0.5,
@@ -457,6 +458,7 @@ def simplify_network(
     # Identify artifacts
     artifacts, threshold = get_artifacts(
         roads,
+        threshold=artifact_threshold,
         threshold_fallback=artifact_threshold_fallback,
         area_threshold_blocks=area_threshold_blocks,
         isoareal_threshold_blocks=isoareal_threshold_blocks,


### PR DESCRIPTION
When doing simplification of small regions, artifact detection may not work as expected. So you may either want to pass an explicit threshold value or at least a fallback - use computed one, if there is none use this.

I will need this in our simplification of central Europe which is done on a partition basis. 

(can't request review from @JGaboardi yet)