### PR TITLE
granular geometry testing on failure

### DIFF
--- a/sgeop/tests/conftest.py
+++ b/sgeop/tests/conftest.py
@@ -88,7 +88,7 @@ def geom_test(
                 unexpected_bad.append(ix)
         if unexpected_bad:
             raise AssertionError(
-                f"Problem in '{aoi}' check locs: {unexpected_bad}"
+                f"Problem in '{aoi}' – check locs: {unexpected_bad}"
             ) from None
 
 

--- a/sgeop/tests/conftest.py
+++ b/sgeop/tests/conftest.py
@@ -22,6 +22,22 @@ geometry_collection = (
     | geopandas.GeoSeries
 )
 
+####################################################
+# see:
+#   - gh#77
+#   - gh#75
+#   - gh#74
+KNOWN_BAD_GEOMS = {
+    "aleppo_1133": [],
+    "auckland_869": [1412],
+    "bucaramanga_4617": [],
+    "douala_809": [],
+    "liege_1656": [921],
+    "slc_4881": [1146],
+    "apalachicola": [746],
+}
+####################################################
+
 
 def polygonize(
     collection: line_collection, as_geom: bool = True
@@ -45,6 +61,7 @@ def geom_test(
     collection1: geometry_collection,
     collection2: geometry_collection,
     tolerance: float = 1e-1,
+    aoi: None | str = None,
 ) -> bool:
     """Testing helper -- geometry verification."""
 
@@ -54,11 +71,25 @@ def geom_test(
     if not is_geopandas(collection2):
         collection2 = geopandas.GeoSeries(collection2)
 
-    assert shapely.equals_exact(
-        collection1.geometry.normalize(),
-        collection2.geometry.normalize(),
-        tolerance=tolerance,
-    ).all()
+    geoms1 = collection1.geometry.normalize()
+    geoms2 = collection2.geometry.normalize()
+
+    try:
+        assert shapely.equals_exact(geoms1, geoms2, tolerance=tolerance).all()
+    except AssertionError:
+        unexpected_bad = []
+        for ix in geoms1.index:
+            g1 = geoms1.loc[ix].geometry
+            g2 = geoms2.loc[ix].geometry
+            if (
+                not shapely.equals_exact(g1, g2, tolerance=tolerance)
+                and ix not in KNOWN_BAD_GEOMS[aoi]
+            ):
+                unexpected_bad.append(ix)
+        if unexpected_bad:
+            raise AssertionError(
+                f"Problem in '{aoi}' check locs: {unexpected_bad}"
+            ) from None
 
 
 def pytest_addoption(parser):

--- a/sgeop/tests/conftest.py
+++ b/sgeop/tests/conftest.py
@@ -79,8 +79,8 @@ def geom_test(
     except AssertionError:
         unexpected_bad = []
         for ix in geoms1.index:
-            g1 = geoms1.loc[ix].geometry
-            g2 = geoms2.loc[ix].geometry
+            g1 = geoms1.loc[ix]
+            g2 = geoms2.loc[ix]
             if (
                 not shapely.equals_exact(g1, g2, tolerance=tolerance)
                 and ix not in KNOWN_BAD_GEOMS[aoi]

--- a/sgeop/tests/test_simplify.py
+++ b/sgeop/tests/test_simplify.py
@@ -34,22 +34,18 @@ def test_simplify_network_small():
     assert observed.shape == known.shape
     assert_series_equal(known._status, observed._status)
 
-    # see gh#74
-    known = known.drop(index=746)
-    observed = observed.drop(index=746)
-
-    pytest.geom_test(known, observed, tolerance=1.5)
+    pytest.geom_test(known, observed, aoi=ac)
 
 
 @pytest.mark.parametrize(
     "aoi,tol,known_length",
     [
         ("aleppo_1133", 2e-1, 4_361_625),
-        ("auckland_869", 2e-1, 1_268_048),
+        ("auckland_869", 3e-1, 1_268_048),
         ("bucaramanga_4617", 2e-1, 1_681_011),
         ("douala_809", 1e-1, 2_961_364),
-        ("liege_1656", 2e-1, 2_350_782),
-        ("slc_4881", 2e-1, 1_762_456),
+        ("liege_1656", 3e-1, 2_350_782),
+        ("slc_4881", 3e-1, 1_762_456),
     ],
 )
 def test_simplify_network_full_fua(aoi, tol, known_length):
@@ -69,4 +65,4 @@ def test_simplify_network_full_fua(aoi, tol, known_length):
 
     if pytest.ubuntu and pytest.env_type != "oldest":
         assert_series_equal(known._status, observed._status)
-        pytest.geom_test(known, observed, tolerance=tol)
+        pytest.geom_test(known, observed, tolerance=tol, aoi=aoi)

--- a/sgeop/tests/test_simplify.py
+++ b/sgeop/tests/test_simplify.py
@@ -34,18 +34,18 @@ def test_simplify_network_small():
     assert observed.shape == known.shape
     assert_series_equal(known._status, observed._status)
 
-    pytest.geom_test(known, observed, aoi=ac)
+    pytest.geom_test(known, observed, tolerance=1.5, aoi=ac)
 
 
 @pytest.mark.parametrize(
     "aoi,tol,known_length",
     [
-        ("aleppo_1133", 2e-1, 4_361_625),
-        ("auckland_869", 3e-1, 1_268_048),
-        ("bucaramanga_4617", 2e-1, 1_681_011),
-        ("douala_809", 1e-1, 2_961_364),
-        ("liege_1656", 3e-1, 2_350_782),
-        ("slc_4881", 3e-1, 1_762_456),
+        ("aleppo_1133", 0.2, 4_361_625),
+        ("auckland_869", 0.3, 1_268_048),
+        ("bucaramanga_4617", 0.2, 1_681_011),
+        ("douala_809", 0.1, 2_961_364),
+        ("liege_1656", 0.3, 2_350_782),
+        ("slc_4881", 0.3, 1_762_456),
     ],
 )
 def test_simplify_network_full_fua(aoi, tol, known_length):


### PR DESCRIPTION
This MR provides granular testing of network geometries on comparison failure, generally due to slight differences in geometry based on GEOS version. Moreover, known exceptions/edge cases can be added to `conftest.py` for easy debugging and sanity check.

* resolves #77 
* resolves #75 
* supersedes #76 
* the [Windows failure](https://github.com/uscuni/sgeop/actions/runs/11696516451/job/32573750004?pr=78#step:3:529) is some weirdness unrelated to this MR.